### PR TITLE
Store and remove loginResponse in AsyncStorage

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -84,6 +84,7 @@ export default function Login() {
 
       const loginData = await apiService.login(kullaniciKod.trim(), sifre.trim(), savedCompanyKey);
 
+      await AsyncStorage.setItem('loginResponse', JSON.stringify(loginData));
       await AsyncStorage.setItem('token', loginData.accessToken);
       await AsyncStorage.setItem('id', loginData.siraNo.toString());
 

--- a/config/http.ts
+++ b/config/http.ts
@@ -25,6 +25,7 @@ const removeToken = async () => {
   try {
     await AsyncStorage.removeItem('token');
     await AsyncStorage.removeItem('id');
+    await AsyncStorage.removeItem('loginResponse');
   } catch (error) {
     console.error('Error removing token:', error);
   }


### PR DESCRIPTION
The login response is now saved to AsyncStorage after a successful login and removed during token cleanup. This helps persist and clear user session data more effectively.